### PR TITLE
Example changes needed to get the javatest protocol tests running

### DIFF
--- a/glassfish-runner/jsonp-platform-tck/pom.xml
+++ b/glassfish-runner/jsonp-platform-tck/pom.xml
@@ -28,19 +28,19 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
+        <arquillian.junit>1.9.1.Final</arquillian.junit>
         <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
         <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version>
         <!-- Use JDK21 to run with GF 8.0.0-M5 -->
         <!-- <glassfish.container.version>8.0.0-M5</glassfish.container.version> -->
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
-        <junit.jupiter.version>5.9.1</junit.jupiter.version>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <tck.artifactId>jsonp-platform-tck</tck.artifactId>
         <tck.version>11.0.0-SNAPSHOT</tck.version>
         <ts.home>/jakartaeetck</ts.home>
         <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
-        <version.jakarta.tck.arquillian>1.0.0-M10</version.jakarta.tck.arquillian>
+        <version.jakarta.tck.arquillian>1.0.0-M12</version.jakarta.tck.arquillian>
     </properties>
 
     <dependencyManagement>
@@ -335,13 +335,13 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.5.0</version>
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>patch-tests</id>
+                        <id>patch-tests-appclient</id>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
@@ -351,8 +351,10 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/parsson.jar</additionalClasspathElement>
                             </additionalClasspathElements>
                             <includes>
-                                <include>**TestsIT.java</include>
+                                <include>com/sun/ts/tests/jsonp/api/patchtests/**TestsIT.java</include>
                             </includes>
+                            <!-- Select the @Tag("tck-appclient") tests -->
+                            <groups>tck-appclient</groups>
                             <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
@@ -361,6 +363,7 @@
                                 <harness.log.traceflag>true</harness.log.traceflag>
                                 <cts.harness.debug>true</cts.harness.debug>
                                 <java.io.tmpdir>/tmp</java.io.tmpdir>
+                                <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
                             </systemPropertyVariables>
                             <environmentVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
@@ -368,7 +371,38 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>pluggability-tests</id>
+                        <id>patch-tests-javatest</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/parsson.jar</additionalClasspathElement>
+                            </additionalClasspathElements>
+                            <includes>
+                                <include>com/sun/ts/tests/jsonp/api/patchtests/**TestsIT.java</include>
+                            </includes>
+                            <!-- Select the @Tag("tck-javatest") tests -->
+                            <groups>tck-javatest</groups>
+                            <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
+                            <systemPropertyVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
+                                <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+                                <junit.log.traceflag>true</junit.log.traceflag>
+                                <harness.log.traceflag>true</harness.log.traceflag>
+                                <cts.harness.debug>true</cts.harness.debug>
+                                <java.io.tmpdir>/tmp</java.io.tmpdir>
+                                <arquillian.xml>arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                            <environmentVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>pluggability-tests-appclient</id>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
@@ -377,9 +411,11 @@
                             <!-- <additionalClasspathElements>
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/parsson.jar</additionalClasspathElement>
                             </additionalClasspathElements> -->
-                            <excludes>
-                                <exclude>**/Patch*.java</exclude>
-                            </excludes>
+                            <includes>
+                                <include>com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/**IT.java</include>
+                            </includes>
+                            <!-- Select the @Tag("tck-appclient") tests -->
+                            <groups>tck-appclient</groups>
                             <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
@@ -388,6 +424,37 @@
                                 <harness.log.traceflag>true</harness.log.traceflag>
                                 <cts.harness.debug>true</cts.harness.debug>
                                 <java.io.tmpdir>/tmp</java.io.tmpdir>
+                                <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                            <environmentVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pluggability-tests-javatest</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <!-- <additionalClasspathElements>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/parsson.jar</additionalClasspathElement>
+                            </additionalClasspathElements> -->
+                            <includes>
+                                <include>com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/**IT.java</include>
+                            </includes>
+                            <!-- Select the @Tag("tck-javatest") tests -->
+                            <groups>tck-javatest</groups>
+                            <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
+                            <systemPropertyVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
+                                <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+                                <junit.log.traceflag>true</junit.log.traceflag>
+                                <harness.log.traceflag>true</harness.log.traceflag>
+                                <cts.harness.debug>true</cts.harness.debug>
+                                <java.io.tmpdir>/tmp</java.io.tmpdir>
+                                <arquillian.xml>arquillian.xml</arquillian.xml>
                             </systemPropertyVariables>
                             <environmentVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>

--- a/glassfish-runner/jsonp-platform-tck/src/test/resources/appclient-arquillian.xml
+++ b/glassfish-runner/jsonp-platform-tck/src/test/resources/appclient-arquillian.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <engine>
+    <property name="deploymentExportPath">target/deployments</property>
+  </engine>
+
+  <group qualifier="glassfish-servers" default="true">
+    <container qualifier="tck-appclient" default="true">
+        <configuration>
+            <property name="glassFishHome">target/glassfish8</property>
+        </configuration>
+        <protocol type="appclient">
+            <property name="runClient">true</property>
+            <property name="runAsVehicle">true</property>
+            <property name="clientEarDir">target/appclient</property>
+            <!-- Need to populate from ts.jte command.testExecuteAppClient setting for glassfish -->
+            <property name="clientCmdLineString">${jboss.home}/bin/appclient.sh;-y;target/test-classes/appclient.yml;-y;target/test-classes/derby.yml;${clientEarDir}/${vehicleArchiveName}.ear#${vehicleArchiveName}_client.jar</property>
+            <!-- Pass ENV vars here -->
+            <property name="clientEnvString">CLASSPATH=${project.build.directory}/appclient/javatest.jar:${project.build.directory}/appclient/libutil.jar:${project.build.directory}/appclient/libcommon.jar</property>
+            <property name="clientDir">${project.basedir}</property>
+            <property name="workDir">${ts.home}/tmp</property>
+            <property name="tsJteFile">${ts.home}/bin/ts.jte</property>
+            <property name="tsSqlStmtFile">${ts.home}/bin/tssql.stmt</property>
+            <property name="trace">true</property>
+            <property name="clientTimeout">20000</property>
+        </protocol>
+    </container>
+  </group>
+
+</arquillian>

--- a/glassfish-runner/jsonp-platform-tck/src/test/resources/arquillian.xml
+++ b/glassfish-runner/jsonp-platform-tck/src/test/resources/arquillian.xml
@@ -4,7 +4,7 @@
             xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
   <engine>
-    <!-- property name="deploymentExportPath">target/</property -->
+    <property name="deploymentExportPath">target/</property>
   </engine>
 
   <group qualifier="glassfish-servers" default="true">
@@ -15,7 +15,7 @@
         <protocol type="javatest">
             <property name="trace">true</property>
             <property name="workDir">/tmp</property>
-            <property name="tsJteFile">/jakartaeetck/bin/ts.jte</property>
+            <property name="tsJteFile">${ts.home}/bin/ts.jte</property>
         </protocol>
     </container>
   </group>

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchAppclientTestsIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchAppclientTestsIT.java
@@ -60,6 +60,7 @@ import java.lang.System.Logger;
  * RFC 6902: JavaScript Object Notation (JSON) Patch compatibility tests.<br>
  * {@see <a href="https://tools.ietf.org/html/rfc6902">RFC 6902</a>}.
  */
+@Tag("tck-appclient")
 @ExtendWith(ArquillianExtension.class)
 public class PatchAppclientTestsIT extends ServiceEETest {
 
@@ -85,8 +86,8 @@ public class PatchAppclientTestsIT extends ServiceEETest {
 
   static final String VEHICLE_ARCHIVE = "patchtests_appclient_vehicle";
   
-  @TargetsContainer("tck-javatest")
-  @OverProtocol("javatest")
+  @TargetsContainer("tck-appclient")
+  @OverProtocol("appclient")
   @Deployment(name = VEHICLE_ARCHIVE, testable = true)
   public static EnterpriseArchive createAppclientDeployment() throws IOException {
   

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchEjbTestsIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchEjbTestsIT.java
@@ -62,6 +62,7 @@ import java.lang.System.Logger;
  * RFC 6902: JavaScript Object Notation (JSON) Patch compatibility tests.<br>
  * {@see <a href="https://tools.ietf.org/html/rfc6902">RFC 6902</a>}.
  */
+@Tag("tck-appclient")
 @ExtendWith(ArquillianExtension.class)
 public class PatchEjbTestsIT extends ServiceEETest {
 
@@ -87,8 +88,8 @@ public class PatchEjbTestsIT extends ServiceEETest {
 
   static final String VEHICLE_ARCHIVE = "patchtests_ejb_vehicle";
   
-  @TargetsContainer("tck-javatest")
-  @OverProtocol("javatest")
+  @TargetsContainer("tck-appclient")
+  @OverProtocol("appclient")
   @Deployment(name = VEHICLE_ARCHIVE, testable = true)
   public static EnterpriseArchive createEjbDeployment() throws Exception {
 

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchJspTestsIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchJspTestsIT.java
@@ -59,6 +59,7 @@ import java.lang.System.Logger;
  * RFC 6902: JavaScript Object Notation (JSON) Patch compatibility tests.<br>
  * {@see <a href="https://tools.ietf.org/html/rfc6902">RFC 6902</a>}.
  */
+@Tag("tck-javatest")
 @ExtendWith(ArquillianExtension.class)
 public class PatchJspTestsIT extends ServiceEETest {
 

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchServletTestsIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchServletTestsIT.java
@@ -58,6 +58,7 @@ import java.lang.System.Logger;
  * RFC 6902: JavaScript Object Notation (JSON) Patch compatibility tests.<br>
  * {@see <a href="https://tools.ietf.org/html/rfc6902">RFC 6902</a>}.
  */
+@Tag("tck-javatest")
 @ExtendWith(ArquillianExtension.class)
 public class PatchServletTestsIT extends ServiceEETest {
 

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientAppclientIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientAppclientIT.java
@@ -82,6 +82,7 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 
 import java.lang.System.Logger;
 
+@Tag("tck-appclient")
 @ExtendWith(ArquillianExtension.class)
 public class ClientAppclientIT extends ServiceEETest {
 
@@ -120,8 +121,8 @@ public class ClientAppclientIT extends ServiceEETest {
 
   static final String VEHICLE_ARCHIVE = "jsonprovidertests_appclient_vehicle";
   
-  @TargetsContainer("tck-javatest")
-  @OverProtocol("javatest")
+  @TargetsContainer("tck-appclient")
+  @OverProtocol("appclient")
   @Deployment(name = VEHICLE_ARCHIVE, testable = true)
   public static EnterpriseArchive createAppclientDeployment() throws Exception {
 

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientEjbIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientEjbIT.java
@@ -84,6 +84,7 @@ import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 
 import java.lang.System.Logger;
 
+@Tag("tck-appclient")
 @ExtendWith(ArquillianExtension.class)
 public class ClientEjbIT extends ServiceEETest {
 
@@ -122,8 +123,8 @@ public class ClientEjbIT extends ServiceEETest {
 
   static final String VEHICLE_ARCHIVE = "jsonprovidertests_ejb_vehicle";
   
-  @TargetsContainer("tck-javatest")
-  @OverProtocol("javatest")
+  @TargetsContainer("tck-appclient")
+  @OverProtocol("appclient")
   @Deployment(name = VEHICLE_ARCHIVE, testable = true)
   public static EnterpriseArchive createEjbDeployment() throws Exception {
 

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientJspIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientJspIT.java
@@ -82,6 +82,7 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 
 import java.lang.System.Logger;
 
+@Tag("tck-javatest")
 @ExtendWith(ArquillianExtension.class)
 public class ClientJspIT extends ServiceEETest {
 

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientServletIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientServletIT.java
@@ -82,6 +82,7 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 
 import java.lang.System.Logger;
 
+@Tag("tck-javatest")
 @ExtendWith(ArquillianExtension.class)
 public class ClientServletIT extends ServiceEETest {
 

--- a/jsonp/src/main/resources/vehicle/jsp/contentRoot/jsp_vehicle.jsp
+++ b/jsonp/src/main/resources/vehicle/jsp/contentRoot/jsp_vehicle.jsp
@@ -17,14 +17,12 @@
 --%>
 
 <%@ page language="java" %>
-<%@ page import="javax.naming.*" %>
 <%@ page import="java.rmi.RemoteException" %>
 <%@ page import="java.util.*" %>
 <%@ page import="java.io.*" %>
 <%@ page import="com.sun.ts.lib.util.*" %>
 <%@ page import="com.sun.ts.lib.harness.*" %>
-<%@ page import="com.sun.ts.lib.porting.*" %>
-<%@ page import="com.sun.javatest.Status" %>
+<%@ page import="com.sun.ts.lib.harness.Status" %>
 <%@ page session="false" %>
 
 <%! Properties properties = null;


### PR DESCRIPTION
With these changes the javatest protocol tests are running. More work is still needed on the appclient tests. Mostly the glassfish-runner/jsonp-platform-tck/src/test/resources/appclient-arquillian.xml protocol section needs to be updated for how glassfish runs an appclient.

```bash
[starksm@scottryzen jsonp-platform-tck]$ mvn -Dts.home=$TS_HOME failsafe:integration-test@pluggability-tests-javatest
...
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.018 s -- in com.sun.ts.tests.jsonp.pluggability.jsonprovidertests.ClientServletIT
Stopping container using command: [/usr/lib/jvm/java-17-openjdk/bin/java, -jar, /home/starksm/Dev/Jakarta/alwin-tck/glassfish-runner/jsonp-platform-tck/target/glassfish8/glassfish/modules/admin-cli.jar, stop-domain, -t]
Waiting finished after 39 ms.
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.873 s
[INFO] Finished at: 2024-08-28T22:07:40-06:00
[INFO] ------------------------------------------------------------------------
```


```bash
[starksm@scottryzen jsonp-platform-tck]$ mvn -Dts.home=$TS_HOME failsafe:integration-test@patch-tests-javatest
...
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.904 s
[INFO] Finished at: 2024-08-28T22:03:47-06:00
[INFO] ------------------------------------------------------------------------
```