### PR TITLE
Changes for the appclient vehicle tests

### DIFF
--- a/glassfish-runner/jsonp-platform-tck/pom.xml
+++ b/glassfish-runner/jsonp-platform-tck/pom.xml
@@ -40,7 +40,7 @@
         <tck.version>11.0.0-SNAPSHOT</tck.version>
         <ts.home>/jakartaeetck</ts.home>
         <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
-        <version.jakarta.tck.arquillian>1.0.0-M12</version.jakarta.tck.arquillian>
+        <version.jakarta.tck.arquillian>1.0.0-M16</version.jakarta.tck.arquillian>
     </properties>
 
     <dependencyManagement>
@@ -49,6 +49,20 @@
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${junit.jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.junit}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-build</artifactId>
+                <version>${arquillian.junit}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -91,7 +105,22 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+            <version>${arquillian.junit}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-test-spi</artifactId>
+            <version>${arquillian.junit}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.core</groupId>
+            <artifactId>arquillian-core-spi</artifactId>
+            <version>${arquillian.junit}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.test</groupId>
+            <artifactId>arquillian-test-impl-base</artifactId>
             <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
@@ -112,7 +141,7 @@
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>1.4</version>
+            <version>1.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -202,6 +231,12 @@
     </repositories>
 
     <build>
+        <testResources>
+            <testResource>
+                <filtering>true</filtering>
+                <directory>src/test/resources</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -242,6 +277,19 @@
                         <configuration>
                             <target>
                                 <chmod dir="target/glassfish8/glassfish/bin/asadmin" perm="777"></chmod>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>echo ts.jte properties</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>generate-test-resources</phase>
+                        <configuration>
+                            <target>
+                                <echo message="ts.jte properties: ${ts.home}/bin/ts.jte"></echo>
+                                <echo message="javaee.home.ri: ${javaee.home.ri}"></echo>
                             </target>
                         </configuration>
                     </execution>
@@ -334,6 +382,24 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <files>
+                                <file>${ts.home}/bin/ts.jte</file>
+                            </files>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.5.0</version>
                 <configuration>
@@ -351,11 +417,21 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/parsson.jar</additionalClasspathElement>
                             </additionalClasspathElements>
                             <includes>
-                                <include>com/sun/ts/tests/jsonp/api/patchtests/**TestsIT.java</include>
+                                <!--include>com/sun/ts/tests/jsonp/api/patchtests/**TestsIT.java</include-->
+                                <include>com.sun.ts.tests.jsonp.pluggability.jsonprovidertests.ClientAppclientIT</include>
+                                <!--include>com.sun.ts.tests.jsonp.api.patchtests.PatchAppclientTestsIT</include-->
                             </includes>
                             <!-- Select the @Tag("tck-appclient") tests -->
                             <groups>tck-appclient</groups>
                             <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
+                            <properties>
+                                <configurationParameters>junit.jupiter.extensions.autodetection.enabled = true
+                                    junit.platform.output.capture.stderr = true
+                                    junit.platform.output.capture.stdout = true
+                                    junit.platform.reporting.open.xml.enabled = true
+                                    junit.platform.reporting.output.dir = target/junit5-reports</configurationParameters>
+                            </properties>
+
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>

--- a/glassfish-runner/jsonp-platform-tck/src/test/java/org/glassfish/AppclientConfigTest.java
+++ b/glassfish-runner/jsonp-platform-tck/src/test/java/org/glassfish/AppclientConfigTest.java
@@ -1,0 +1,33 @@
+package org.glassfish;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.config.descriptor.api.ProtocolDef;
+import org.jboss.arquillian.container.test.impl.MapObject;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.junit.jupiter.api.Test;
+import tck.arquillian.protocol.appclient.AppClientProtocolConfiguration;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Map;
+
+public class AppclientConfigTest {
+    @Test
+    public void testLoadAppclientConfig() throws Exception{
+        System.out.println("AppclientConfigTest.testLoadAppclientConfig");
+        InputStream input = AppclientConfigTest.class.getResource("/appclient-arquillian.xml").openStream();
+        ArquillianDescriptor descriptor = Descriptors.importAs(ArquillianDescriptor.class)
+                .fromStream(input);
+        AppClientProtocolConfiguration config = new AppClientProtocolConfiguration();
+        ProtocolDef appclientDef = descriptor.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0);
+        System.out.println(appclientDef);
+        Map<String, String> props = appclientDef.getProtocolProperties();
+        System.out.println(props);
+        MapObject.populate(config, props);
+        System.out.println(config.getClientCmdLineString());
+        System.out.println("--- ENV array:");
+        System.out.println(Arrays.asList(config.clientEnvAsArray()));
+        System.out.println("--- CMD array:");
+        System.out.println(Arrays.asList(config.clientCmdLineAsArray()));
+    }
+}

--- a/glassfish-runner/jsonp-platform-tck/src/test/resources/appclient-arquillian.xml
+++ b/glassfish-runner/jsonp-platform-tck/src/test/resources/appclient-arquillian.xml
@@ -16,10 +16,40 @@
             <property name="runClient">true</property>
             <property name="runAsVehicle">true</property>
             <property name="clientEarDir">target/appclient</property>
+            <property name="unpackClientEar">true</property>
             <!-- Need to populate from ts.jte command.testExecuteAppClient setting for glassfish -->
-            <property name="clientCmdLineString">${jboss.home}/bin/appclient.sh;-y;target/test-classes/appclient.yml;-y;target/test-classes/derby.yml;${clientEarDir}/${vehicleArchiveName}.ear#${vehicleArchiveName}_client.jar</property>
+            <property name="clientCmdLineString">target/glassfish8/glassfish/bin/appclient \
+                -Djdk.tls.client.enableSessionTicketExtension=false \
+                -Djdk.tls.server.enableSessionTicketExtension=false \
+                -Djava.security.policy=${glassfish.home}/lib/appclient/client.policy \
+                -Dcts.tmp=$harness.temp.directory \
+                -Djava.security.auth.login.config=${glassfish.home}/lib/appclient/appclientlogin.conf \
+                -Djava.protocol.handler.pkgs=javax.net.ssl \
+                -Djavax.net.ssl.keyStore=${ts.home}/bin/certificates/clientcert.jks \
+                -Djavax.net.ssl.keyStorePassword=changeit \
+                -Djavax.net.ssl.trustStore=${ri.domain}/config/cacerts.jks \
+                -Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl \
+                -Djavax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl \
+                -Djavax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl \
+                -Dorg.xml.sax.driver=com.sun.org.apache.xerces.internal.parsers.SAXParser \
+                -Dorg.xml.sax.parser=org.xml.sax.helpers.XMLReaderAdapter \
+                -Doracle.jdbc.J2EE13Compliant=true \
+                -Doracle.jdbc.mapDateToTimestamp \
+                -Dstartup.login=false \
+                -Dauth.gui=false \
+                -Dlog.file.location=${log.file.location} \
+                -Dri.log.file.location=${ri.log.file.location} \
+                -DwebServerHost.2=${webServerHost.2} \
+                -DwebServerPort.2=${webServerPort.2} \
+                -Dprovider.configuration.file=${provider.configuration.file} \
+                -Ddeliverable.class=${deliverable.class} \
+                -jar \
+                ${clientEarDir}/${clientAppArchive}
+            </property>
+            <property name="cmdLineArgSeparator">\\</property>
             <!-- Pass ENV vars here -->
-            <property name="clientEnvString">CLASSPATH=${project.build.directory}/appclient/javatest.jar:${project.build.directory}/appclient/libutil.jar:${project.build.directory}/appclient/libcommon.jar</property>
+            <property name="clientEnvString">PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
+                APPCPATH=target/appclient/lib/arquillian-protocol-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar</property>
             <property name="clientDir">${project.basedir}</property>
             <property name="workDir">${ts.home}/tmp</property>
             <property name="tsJteFile">${ts.home}/bin/ts.jte</property>

--- a/glassfish-runner/jsonp-platform-tck/src/test/resources/logging.properties
+++ b/glassfish-runner/jsonp-platform-tck/src/test/resources/logging.properties
@@ -1,0 +1,15 @@
+handlers=java.util.logging.FileHandler,java.util.logging.ConsoleHandler
+
+tck.jakarta.platform.ant.level = FINER
+org.glassfish.appclient.client.level = FINER
+
+java.util.logging.FileHandler.pattern = tck-run.log
+java.util.logging.FileHandler.level = FINEST
+#java.util.logging.FileHandler.formatter = tck.conversion.log.TestLogFormatter
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+# date(1), source(2), logger(3), level(4), message(5), thrown(6)
+java.util.logging.SimpleFormatter.format = [%1$tH:%tM:%1$tS.%1$tL] %2$.12s/%4$s %5$s %n
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchAppclientTestsIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchAppclientTestsIT.java
@@ -16,6 +16,7 @@
 
 package com.sun.ts.tests.jsonp.api.patchtests;
 
+import java.io.PrintWriter;
 import java.util.stream.Collectors;
 import java.nio.charset.StandardCharsets;
 import java.io.InputStreamReader;
@@ -25,6 +26,8 @@ import java.io.BufferedReader;
 import java.io.StringReader;
 import java.util.Properties;
 import java.net.URL;
+
+import com.sun.ts.lib.harness.Status;
 import com.sun.ts.tests.jsonp.api.common.JsonPTest;
 import com.sun.ts.tests.jsonp.api.common.TestResult;
 import com.sun.ts.lib.harness.ServiceEETest;
@@ -93,11 +96,13 @@ public class PatchAppclientTestsIT extends ServiceEETest {
   
     JavaArchive patchtests_appclient_vehicle_client = ShrinkWrap.create(JavaArchive.class, "patchtests_appclient_vehicle_client.jar");
     patchtests_appclient_vehicle_client.addClass(PatchAppclientTestsIT.class)
+      .addClass(CommonOperation.class)
+      .addClass(PatchCreate.class)
+      .addPackage(TestResult.class.getPackage())
       .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class)
       .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class)
       .addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class)
       .addClass(com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.class)
-      .addClass(com.sun.ts.tests.jsonp.common.JSONP_Data.class)
       .addClass(com.sun.ts.tests.jsonp.common.JSONP_Util.class)
       .addClass(com.sun.ts.tests.jsonp.common.MyBufferedReader.class)
       .addClass(com.sun.ts.tests.jsonp.common.MyBufferedWriter.class)
@@ -121,6 +126,12 @@ public class PatchAppclientTestsIT extends ServiceEETest {
     ear.addAsModule(patchtests_appclient_vehicle_client);
     return ear;
 
+  }
+
+  public static void main(String[] args) {
+    PatchAppclientTestsIT theTests = new PatchAppclientTestsIT();
+    Status s = theTests.run(args, new PrintWriter(System.out), new PrintWriter(System.err));
+    s.exit();
   }
 
     /*

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchEjbTestsIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchEjbTestsIT.java
@@ -121,12 +121,13 @@ public class PatchEjbTestsIT extends ServiceEETest {
     JavaArchive patchtests_ejb_vehicle_ejb = ShrinkWrap.create(JavaArchive.class, "patchtests_ejb_vehicle_ejb.jar");
     // The class files
     patchtests_ejb_vehicle_ejb.addClasses(
+        CommonOperation.class,
+        PatchCreate.class,
         com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
         com.sun.ts.lib.harness.EETest.Fault.class,
         com.sun.ts.tests.common.vehicle.ejb.EJBVehicle.class,
         com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
         com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class,
-        // com.sun.ts.tests.common.vehicle.ejb.EJBVehicleHome.class,
         com.sun.ts.lib.harness.EETest.class,
         com.sun.ts.lib.harness.ServiceEETest.class,
         com.sun.ts.lib.harness.EETest.SetupException.class,
@@ -139,6 +140,7 @@ public class PatchEjbTestsIT extends ServiceEETest {
         com.sun.ts.tests.jsonp.common.MyJsonLocation.class,
         PatchEjbTestsIT.class
     );
+    patchtests_ejb_vehicle_ejb.addPackage(TestResult.class.getPackage());
     // The ejb-jar.xml descriptor
     URL ejbResURL = PatchEjbTestsIT.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_ejb.xml");
     if(ejbResURL != null) {

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientAppclientIT.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientAppclientIT.java
@@ -150,7 +150,7 @@ public class ClientAppclientIT extends ServiceEETest {
     if(resURL != null) {
       jsonprovidertests_appclient_vehicle_client.addAsManifestResource(resURL, "application-client.xml");
     }
-    jsonprovidertests_appclient_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + ClientAppclientIT.class.getName() + "\n"), "MANIFEST.MF");
+    jsonprovidertests_appclient_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient"), "MANIFEST.MF");
 
 
     JavaArchive jarArchive = ShrinkWrap.create(JavaArchive.class, "jsonp_alternate_provider.jar")
@@ -215,11 +215,11 @@ public class ClientAppclientIT extends ServiceEETest {
 
   private String providerPath = null;
 
-  // public static void main(String[] args) {
-  //   Client theTests = new Client();
-  //   Status s = theTests.run(args, System.out, System.err);
-  //   s.exit();
-  // }
+  public static void main(String[] args) {
+    ClientAppclientIT theTests = new ClientAppclientIT();
+     Status s = theTests.run(args, System.out, System.err);
+     s.exit();
+  }
 
   /* Test setup */
 


### PR DESCRIPTION
This updates the runner for the appclient clients. Some are working, but some are still failing. I have created this glassfish issue for the problem I'm seeing:
https://github.com/eclipse-ee4j/glassfish/issues/25143
