### PR TITLE
Some fixes for the com.sun.ts.tests.jms.ee20.cditests.ejbweb.ClientTest

### DIFF
--- a/glassfish-runner/messaging-platform-tck/messaging-platform-tck-run/pom.xml
+++ b/glassfish-runner/messaging-platform-tck/messaging-platform-tck-run/pom.xml
@@ -195,33 +195,6 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    
-                    <execution>
-                        <id>02-copy-lib</id>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>jakarta.tck</groupId>
-                                    <artifactId>common</artifactId>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                    <destFileName>common.jar</destFileName>
-                                </artifactItem>
-                                
-                                <artifactItem>
-                                    <groupId>jakarta.tck</groupId>
-                                    <artifactId>jms-platform-tck</artifactId>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                    <destFileName>jms-tck.jar</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
 
@@ -680,54 +653,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.6.1</version>
-                        <executions>
-                            <execution>
-                                <id>03-copy-lib</id>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <phase>generate-resources</phase>
-                                <configuration>
-                                    <artifactItems>
-                                        <!-- The application client container needs these two dependencies -->
-                                        <artifactItem>
-                                            <groupId>jakarta.tck.arquillian</groupId>
-                                            <artifactId>tck-porting-lib</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                            <destFileName>tck-porting-lib.jar</destFileName>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>jakarta.tck.arquillian</groupId>
-                                            <artifactId>arquillian-protocol-lib</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                            <destFileName>arquillian-protocol-lib.jar</destFileName>
-                                        </artifactItem>
-
-                                        <!-- 
-                                            AppClientDeploymentPackager needs this on the Eclipse CI since it can't fully resolve
-                                            jakarta.tck.arquillian:arquillian-protocol-lib in code for some reason.
-                                        -->
-                                        <artifactItem>
-                                            <groupId>jakarta.tck.arquillian</groupId>
-                                            <artifactId>arquillian-protocol-lib</artifactId>
-                                            <!-- <version>${jakarta.tck.arquillian.version}</version> -->
-                                            <type>jar</type>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/protocol</outputDirectory>
-                                            <destFileName>protocol.jar</destFileName>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
                         <executions>
@@ -889,7 +814,8 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <includes> 
-                                <include>com.sun.ts.tests.jms.ee20.**.*Test</include>
+                                <!--include>com.sun.ts.tests.jms.ee20.**.*Test</include-->
+                                <include>com.sun.ts.tests.jms.ee20.cditests.ejbweb.ClientTest</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/glassfish-runner/messaging-platform-tck/messaging-platform-tck-run/src/test/resources/appclient-arquillian.xml
+++ b/glassfish-runner/messaging-platform-tck/messaging-platform-tck-run/src/test/resources/appclient-arquillian.xml
@@ -15,6 +15,9 @@
     <container qualifier="tck-appclient" default="true">
         <configuration>
             <property name="glassFishHome">target/glassfish8</property>
+            <property name="outputToConsole">true</property>
+            <property name="debug">false</property>
+            <property name="suspend">false</property>
         </configuration>
         <protocol type="appclient" default="true">
             <property name="runClient">true</property>
@@ -53,8 +56,8 @@
             <!-- Pass ENV vars here -->
             <!-- <property name="clientEnvString">PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
                 APPCPATH=${glassfish.home}/glassfish/lib/arquillian-protocol-lib.jar:${glassfish.home}/glassfish/lib/tck-porting-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar:${glassfish.home}/glassfish/modules/security.jar</property> -->
-            <property name="clientEnvString">PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
-                APPCPATH=target/lib/arquillian-protocol-lib.jar:target/lib/tck-porting-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar:${glassfish.home}/glassfish/modules/security.jar:${glassfish.home}/glassfish/lib/gf-client.jar</property>
+            <property name="clientEnvString">AS_JAVA=${env.JAVA_HOME};PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
+                APPCPATH=target/appclient/lib/arquillian-protocol-lib.jar:${glassfish.home}/glassfish/modules/security.jar:${glassfish.home}/glassfish/lib/gf-client.jar</property>
             <property name="clientDir">${project.basedir}</property>
             <property name="workDir">/tmp</property>
             <property name="tsJteFile">jakartaeetck/bin/ts.jte</property>

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/Client.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/Client.java
@@ -51,7 +51,7 @@ public class Client extends EETest {
   private String SERVLET = "/cditestsejbweb_web/ServletTest";
 
   // @EJB(name = "ejb/CDITestsEjbWebClntBean")
-  static EjbClientIF ejbclient;
+  EjbClientIF ejbclient;
 
   private static final long serialVersionUID = 1L;
 
@@ -384,7 +384,7 @@ public class Client extends EETest {
       TestUtil.logMsg("--------------------------------");
       TestUtil.logMsg("sendRecvQueueTestUsingCDIFromEjb");
       TestUtil.logMsg("--------------------------------");
-      boolean passEjb = ejbclient.echo("sendRecvQueueTestUsingCDIFromEjb");
+      boolean passEjb = ejbclient.sendRecvQueueTestUsingCDIFromEjb();
       if (!passEjb) {
         pass = false;
         TestUtil.logErr("CDI injection test failed from Ejb");
@@ -425,7 +425,7 @@ public class Client extends EETest {
       TestUtil.logMsg("--------------------------------");
       TestUtil.logMsg("sendRecvTopicTestUsingCDIFromEjb");
       TestUtil.logMsg("--------------------------------");
-      boolean passEjb = ejbclient.echo("sendRecvTopicTestUsingCDIFromEjb");
+      boolean passEjb = ejbclient.sendRecvTopicTestUsingCDIFromEjb();
       if (!passEjb) {
         pass = false;
         TestUtil.logErr("CDI injection test failed from Ejb");
@@ -463,7 +463,7 @@ public class Client extends EETest {
       TestUtil.logMsg("-------------------------------------");
       TestUtil.logMsg("sendRecvUsingCDIDefaultFactoryFromEjb");
       TestUtil.logMsg("-------------------------------------");
-      boolean passEjb = ejbclient.echo("sendRecvUsingCDIDefaultFactoryFromEjb");
+      boolean passEjb = ejbclient.sendRecvUsingCDIDefaultFactoryFromEjb();
       if (!passEjb) {
         pass = false;
         TestUtil.logErr("CDI injection test failed from Ejb");
@@ -511,8 +511,7 @@ public class Client extends EETest {
       TestUtil.logMsg("---------------------------------------");
       TestUtil.logMsg("verifySessionModeOnCDIJMSContextFromEjb");
       TestUtil.logMsg("---------------------------------------");
-      boolean passEjb = ejbclient
-          .echo("verifySessionModeOnCDIJMSContextFromEjb");
+      boolean passEjb = ejbclient.verifySessionModeOnCDIJMSContextFromEjb();
       if (!passEjb) {
         pass = false;
         TestUtil.logErr("CDI injection test failed from Ejb");
@@ -551,8 +550,7 @@ public class Client extends EETest {
       TestUtil.logMsg("--------------------------------------");
       TestUtil.logMsg("testRestrictionsOnCDIJMSContextFromEjb");
       TestUtil.logMsg("--------------------------------------");
-      boolean passEjb = ejbclient
-          .echo("testRestrictionsOnCDIJMSContextFromEjb");
+      boolean passEjb = ejbclient.testRestrictionsOnCDIJMSContextFromEjb();
       if (!passEjb) {
         pass = false;
         TestUtil.logErr("CDI injection test failed from Ejb");
@@ -584,15 +582,14 @@ public class Client extends EETest {
       TestUtil.logMsg("------------------------------------------");
       TestUtil.logMsg("testActiveJTAUsingCDIAcross2MethodsFromEjb");
       TestUtil.logMsg("------------------------------------------");
-      boolean passEjb = ejbclient
-          .echo("testActiveJTAUsingCDICallMethod1FromEjb");
+      boolean passEjb = ejbclient.testActiveJTAUsingCDICallMethod1FromEjb();
       if (!passEjb) {
         pass = false;
         TestUtil.logErr("CDI injection test failed from Ejb");
       } else {
         TestUtil.logMsg("CDI injection test passed from Ejb");
       }
-      passEjb = ejbclient.echo("testActiveJTAUsingCDICallMethod2FromEjb");
+      passEjb = ejbclient.testActiveJTAUsingCDICallMethod2FromEjb();
       if (!passEjb) {
         pass = false;
         TestUtil.logErr("CDI injection test failed from Ejb");

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/ClientTest.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/ClientTest.java
@@ -58,6 +58,7 @@ public class ClientTest extends com.sun.ts.tests.jms.ee20.cditests.ejbweb.Client
         @OverProtocol("appclient")
         @Deployment(name = "cditestsejbweb", order = 2)
         public static EnterpriseArchive createDeployment(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+            System.out.println("Client.class.location: "+Client.class.getProtectionDomain().getCodeSource().getLocation());
         // War
             // the war with the correct archive name
             WebArchive cditestsejbweb_web = ShrinkWrap.create(WebArchive.class, "cditestsejbweb_web.war");
@@ -81,14 +82,7 @@ public class ClientTest extends com.sun.ts.tests.jms.ee20.cditests.ejbweb.Client
             // Any libraries added to the war
 
             // Web content
-            // warResURL = Client.class.getResource("/com/sun/ts/tests/jms/ee20/cditests/ejbweb/cditestsejbweb_web.xml");
-            // if(warResURL != null) {
-            //   cditestsejbweb_web.addAsWebResource(warResURL, "/cditestsejbweb_web.xml");
-            // }
-            warResURL = Client.class.getResource("/com/sun/ts/tests/jms/ee20/cditests/resources/beans.xml");
-            if(warResURL != null) {
-              cditestsejbweb_web.addAsWebInfResource(warResURL, "beans.xml");
-            }
+            cditestsejbweb_web.addAsWebInfResource(new StringAsset(""), "beans.xml");
 
            // Call the archive processor
            archiveProcessor.processWebArchive(cditestsejbweb_web, Client.class, warResURL);
@@ -106,21 +100,11 @@ public class ClientTest extends com.sun.ts.tests.jms.ee20.cditests.ejbweb.Client
             EjbClientIFProxy.class
             );
             // The application-client.xml descriptor
-            // URL resURL = null;
-            // URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appclient/appclient_vehicle_client.xml");
-            // if(resURL != null) {
-            //   cditestsejbweb_client.addAsManifestResource(resURL, "application-client.xml");
-            // }
-            // // The sun-application-client.xml file need to be added or should this be in in the vendor Arquillian extension?
-            // resURL = Client.class.getResource("jar.sun-application-client.xml");
-            // if(resURL != null) {
-            //   cditestsejbweb_client.addAsManifestResource(resURL, "application-client.xml");
-            // }
-            URL resURL = null;
+            // The sun-application-client.xml
             cditestsejbweb_client.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
 
             // Call the archive processor
-            archiveProcessor.processClientArchive(cditestsejbweb_client, Client.class, resURL);
+            archiveProcessor.processClientArchive(cditestsejbweb_client, Client.class, null);
 
         // Ejb
             // the jar with the correct archive name
@@ -132,18 +116,11 @@ public class ClientTest extends com.sun.ts.tests.jms.ee20.cditests.ejbweb.Client
             );
             // The ejb-jar.xml descriptor
             URL ejbResURL = Client.class.getResource("cditestsejbweb_ejb.xml");
-            if(ejbResURL != null) {
-              cditestsejbweb_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
-            }
+            cditestsejbweb_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
             // The sun-ejb-jar.xml file
             ejbResURL = Client.class.getResource("cditestsejbweb_ejb.jar.sun-ejb-jar.xml");
-            if(ejbResURL != null) {
-              cditestsejbweb_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
-            }
-            ejbResURL = Client.class.getResource("/com/sun/ts/tests/jms/ee20/cditests/resources/beans.xml");
-            if(ejbResURL != null) {
-              cditestsejbweb_ejb.addAsManifestResource(ejbResURL, "beans.xml");
-            }
+            cditestsejbweb_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
+            cditestsejbweb_ejb.addAsManifestResource(new StringAsset(""), "beans.xml");
 
             // Call the archive processor
             archiveProcessor.processEjbArchive(cditestsejbweb_ejb, Client.class, ejbResURL);

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/EjbClient.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/EjbClient.java
@@ -16,6 +16,8 @@
 
 package com.sun.ts.tests.jms.ee20.cditests.ejbweb;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Properties;
 
 import com.sun.ts.lib.util.RemoteLoggingInitException;
@@ -25,8 +27,7 @@ import com.sun.ts.lib.util.TestUtil;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
 import jakarta.ejb.EJBException;
-import jakarta.ejb.Remote;
-import jakarta.ejb.Stateful;
+import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.IllegalStateRuntimeException;
@@ -42,7 +43,7 @@ import jakarta.jms.Topic;
 import jakarta.jms.TopicConnectionFactory;
 import jakarta.transaction.UserTransaction;
 
-@Stateful(name = "CDITestsEjbWebClntBean")
+@Stateless(name = "CDITestsEjbWebClntBean")
 // @Remote({ EjbClientIF.class })
 public class EjbClient implements EjbClientIF {
 
@@ -50,7 +51,7 @@ public class EjbClient implements EjbClientIF {
 
   private static final long serialVersionUID = 1L;
 
-  long timeout;
+  long timeout = 5000;
 
   private static int testsExecuted = 0;
 
@@ -116,6 +117,7 @@ public class EjbClient implements EjbClientIF {
   @PostConstruct
   public void postConstruct() {
     System.out.println("EjbClient:postConstruct()");
+    TestUtil.logMsg("EjbClient:postConstruct()");
     System.out.println("queue=" + queue);
     System.out.println("topic=" + topic);
     System.out.println("cfactory=" + cfactory);
@@ -391,7 +393,10 @@ public class EjbClient implements EjbClientIF {
             + printSessionMode(JMSContext.AUTO_ACKNOWLEDGE));
       }
     } catch (Exception e) {
-      TestUtil.logErr("Caught exception: " + e);
+      StringWriter sw = new StringWriter();
+      e.printStackTrace(new PrintWriter(sw));
+      e.printStackTrace();
+      TestUtil.logErr("Caught exception:\n" + sw);
       pass = false;
     }
     return pass;
@@ -408,7 +413,10 @@ public class EjbClient implements EjbClientIF {
       } catch (IllegalStateRuntimeException e) {
         TestUtil.logMsg("Caught expected IllegalStateRuntimeException");
       } catch (Exception e) {
-        TestUtil.logErr("Caught unexpected Exception: " + e);
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+      e.printStackTrace();
+      TestUtil.logErr("Caught unexpected exception:\n" + sw);
         pass = false;
       }
       TestUtil.logMsg(
@@ -418,7 +426,10 @@ public class EjbClient implements EjbClientIF {
       } catch (IllegalStateRuntimeException e) {
         TestUtil.logMsg("Caught expected IllegalStateRuntimeException");
       } catch (Exception e) {
-        TestUtil.logErr("Caught unexpected Exception: " + e);
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+      e.printStackTrace();
+      TestUtil.logErr("Caught unexpected exception:\n" + sw);
         pass = false;
       }
       TestUtil.logMsg(
@@ -428,7 +439,10 @@ public class EjbClient implements EjbClientIF {
       } catch (IllegalStateRuntimeException e) {
         TestUtil.logMsg("Caught expected IllegalStateRuntimeException");
       } catch (Exception e) {
-        TestUtil.logErr("Caught unexpected Exception: " + e);
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+      e.printStackTrace();
+      TestUtil.logErr("Caught unexpected exception:\n" + sw);
         pass = false;
       }
       TestUtil.logMsg(
@@ -438,7 +452,10 @@ public class EjbClient implements EjbClientIF {
       } catch (IllegalStateRuntimeException e) {
         TestUtil.logMsg("Caught expected IllegalStateRuntimeException");
       } catch (Exception e) {
-        TestUtil.logErr("Caught unexpected Exception: " + e);
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+      e.printStackTrace();
+      TestUtil.logErr("Caught unexpected exception:\n" + sw);
         pass = false;
       }
       TestUtil.logMsg(
@@ -448,7 +465,10 @@ public class EjbClient implements EjbClientIF {
       } catch (IllegalStateRuntimeException e) {
         TestUtil.logMsg("Caught expected IllegalStateRuntimeException");
       } catch (Exception e) {
-        TestUtil.logErr("Caught unexpected Exception: " + e);
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        e.printStackTrace();
+        TestUtil.logErr("Caught unexpected exception:\n" + sw);
         pass = false;
       }
       TestUtil.logMsg(
@@ -458,7 +478,10 @@ public class EjbClient implements EjbClientIF {
       } catch (IllegalStateRuntimeException e) {
         TestUtil.logMsg("Caught expected IllegalStateRuntimeException");
       } catch (Exception e) {
-        TestUtil.logErr("Caught unexpected Exception: " + e);
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        e.printStackTrace();
+        TestUtil.logErr("Caught unexpected exception:\n" + sw);
         pass = false;
       }
       TestUtil.logMsg(
@@ -468,7 +491,10 @@ public class EjbClient implements EjbClientIF {
       } catch (IllegalStateRuntimeException e) {
         TestUtil.logMsg("Caught expected IllegalStateRuntimeException");
       } catch (Exception e) {
-        TestUtil.logErr("Caught unexpected Exception: " + e);
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        e.printStackTrace();
+        TestUtil.logErr("Caught unexpected exception:\n" + sw);
         pass = false;
       }
       TestUtil.logMsg(
@@ -478,7 +504,10 @@ public class EjbClient implements EjbClientIF {
       } catch (IllegalStateRuntimeException e) {
         TestUtil.logMsg("Caught expected IllegalStateRuntimeException");
       } catch (Exception e) {
-        TestUtil.logErr("Caught unexpected Exception: " + e);
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        e.printStackTrace();
+        TestUtil.logErr("Caught unexpected exception:\n" + sw);
         pass = false;
       }
       TestUtil.logMsg(
@@ -488,7 +517,10 @@ public class EjbClient implements EjbClientIF {
       } catch (IllegalStateRuntimeException e) {
         TestUtil.logMsg("Caught expected IllegalStateRuntimeException");
       } catch (Exception e) {
-        TestUtil.logErr("Caught unexpected Exception: " + e);
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        e.printStackTrace();
+        TestUtil.logErr("Caught unexpected exception:\n" + sw);
         pass = false;
       }
       TestUtil.logMsg(
@@ -498,11 +530,17 @@ public class EjbClient implements EjbClientIF {
       } catch (IllegalStateRuntimeException e) {
         TestUtil.logMsg("Caught expected IllegalStateRuntimeException");
       } catch (Exception e) {
-        TestUtil.logErr("Caught unexpected Exception: " + e);
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        e.printStackTrace();
+        TestUtil.logErr("Caught unexpected exception:\n" + sw);
         pass = false;
       }
     } catch (Exception e) {
-      TestUtil.logErr("Caught exception: " + e);
+      StringWriter sw = new StringWriter();
+      e.printStackTrace(new PrintWriter(sw));
+      e.printStackTrace();
+      TestUtil.logErr("Caught exception:\n" + sw);
       pass = false;
     }
     return pass;
@@ -532,7 +570,10 @@ public class EjbClient implements EjbClientIF {
       TestUtil.logMsg(
           "Exit method and let the next method call complete the JTA transaction");
     } catch (Exception e) {
-      TestUtil.logErr("Caught exception: " + e);
+      StringWriter sw = new StringWriter();
+      e.printStackTrace(new PrintWriter(sw));
+      e.printStackTrace();
+      TestUtil.logErr("Caught exception:\n" + sw);
       pass = false;
     }
     return pass;
@@ -581,7 +622,10 @@ public class EjbClient implements EjbClientIF {
         }
       }
     } catch (Exception e) {
-      TestUtil.logErr("Caught exception: " + e);
+      StringWriter sw = new StringWriter();
+      e.printStackTrace(new PrintWriter(sw));
+      e.printStackTrace();
+      TestUtil.logErr("Caught exception:\n" + sw);
       pass = false;
     } finally {
       try {

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/EjbClientIF.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/EjbClientIF.java
@@ -20,8 +20,6 @@ public interface EjbClientIF {
 
   public void init(java.util.Properties p);
 
-  public boolean echo(String testName);
-
   public boolean sendRecvQueueTestUsingCDIFromEjb();
 
   public boolean sendRecvTopicTestUsingCDIFromEjb();

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/EjbClientIFProxy.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/EjbClientIFProxy.java
@@ -44,11 +44,9 @@ public class EjbClientIFProxy implements InvocationHandler {
             ok = true;
         } else if(methodName.equals("toString")) {
             return Client.class.getName()+"-proxy";
-        } else if(methodName.startsWith("test")) {
+        } else {
             RemoteStatus status = sendGet(methodName);
             ok = status.toStatus().isPassed();
-        } else {
-            throw new UnsupportedOperationException("Method not supported: " + methodName);
         }
 
         return ok;
@@ -58,7 +56,8 @@ public class EjbClientIFProxy implements InvocationHandler {
         String host = TestUtil.getProperty(testProps, "webServerHost", "localhost");
         String port = TestUtil.getProperty(testProps, "webServerPort", "8080");
 
-        URI uri = URI.create("http://"+host + ":" + port + "/appclientproxy/appclient_novehicle?test=" + methodName);
+        URI uri = URI.create("http://"+host + ":" + port + "/appclient_novehicle/?test=" + methodName);
+        System.out.println("sendGet().uri: " + uri);
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(uri)
                 .GET()
@@ -66,6 +65,8 @@ public class EjbClientIFProxy implements InvocationHandler {
         HttpResponse<byte[]> response = HttpClient.newBuilder()
                 .build()
                 .send(request, HttpResponse.BodyHandlers.ofByteArray());
+        System.out.println("sendGet() response: " + response.statusCode());
+        System.out.println("sendGet() response.headers: " + response.headers());
         if (response.statusCode() != 200) {
             String msg = String.format("Failed to send %s(), status code %d",
                     methodName, response.statusCode());

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/EjbServletTarget.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/EjbServletTarget.java
@@ -13,11 +13,11 @@ import java.util.logging.Logger;
 /**
  * Replaces the remote ejb call used by Client with a servlet call.
  */
-@WebServlet(name = "EjbServletTarget", urlPatterns = {"/appclient_novehicle"})
+@WebServlet(name = "EjbServletTarget", urlPatterns = {"/*"})
 public class EjbServletTarget extends ServletNoVehicle<Client> {
     private static final Logger log = Logger.getLogger(EjbServletTarget.class.getName());
     
-    @EJB
+    @EJB(name = "ejb/CDITestsEjbWebClntBean", beanName = "CDITestsEjbWebClntBean")
     EjbClientIF injectedBean;
 
     public EjbServletTarget() {

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/ServletNoVehicle.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/ServletNoVehicle.java
@@ -19,21 +19,26 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.rmi.RemoteException;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 public class ServletNoVehicle<T extends EETest> extends HttpServlet {
+    static Logger log = Logger.getLogger(ServletNoVehicle.class.getName());
+    public ServletNoVehicle() {}
     protected Properties properties = null;
     protected String[] arguments = null;
     protected EETest testObj = null;
     protected String testName;
 
     public void init(ServletConfig config) throws ServletException {
-        TestUtil.logTrace("init " + this.getClass().getName() + " ...");
+        TestUtil.logMsg("init " + this.getClass().getName() + " ...");
+        log.info("ServletNoVehicle.init " + this.getClass().getName() + " ...");
         super.init(config);
     }
 
     public void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
         try {
-            TestUtil.logTrace("ServletVehicle - In doGet");
+            TestUtil.logMsg("ServletVehicle - In doGet");
+            log.info("ServletNoVehicle.doGet - In doGet");
             Type t = getClass().getGenericSuperclass();
             ParameterizedType pt = (ParameterizedType) t;
             Class<EETest> testClass = (Class<EETest>) pt.getActualTypeArguments()[0];

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/application.xml
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/application.xml
@@ -30,6 +30,12 @@
     </web>
   </module>
   <module>
+    <web>
+      <web-uri>appclientproxy.war</web-uri>
+      <context-root>appclient_novehicle</context-root>
+    </web>
+  </module>
+  <module>
     <ejb>cditestsejbweb_ejb.jar</ejb>
   </module>
 </application>

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/cditestsejbweb_ejb.xml
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/cditests/ejbweb/cditestsejbweb_ejb.xml
@@ -25,7 +25,7 @@
 		<session>
 			<ejb-name>CDITestsEjbWebClntBean</ejb-name>
 			<ejb-class>com.sun.ts.tests.jms.ee20.cditests.ejbweb.EjbClient</ejb-class>
-			<session-type>Stateful</session-type>
+			<session-type>Stateless</session-type>
 			<transaction-type>Bean</transaction-type>
 			<resource-ref>
 				<res-ref-name>jms/MyQueueConnectionFactory</res-ref-name>


### PR DESCRIPTION
This fixes the name not found issue and has 5 tests passing, but there are still 8 errors:

```
starksm@Scotts-Mac-Studio messaging-platform-tck-run % mvn -Pstaging,full,appclient,ee20 integration-test -Dit.test=com.sun.ts.tests.jms.ee20.cditests.ejbweb.ClientTest
…
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   ClientTest.sendRecvQueueTestUsingCDIFromManagedBean »  Test case throws exception: sendRecvQueueTestUsingCDIFromManagedBean failed
[ERROR]   ClientTest.sendRecvQueueTestUsingCDIFromServlet »  Test case throws exception: sendRecvQueueTestUsingCDIFromServlet failed
[ERROR]   ClientTest.sendRecvTopicTestUsingCDIFromManagedBean »  Test case throws exception: sendRecvTopicTestUsingCDIFromManagedBean failed
[ERROR]   ClientTest.sendRecvTopicTestUsingCDIFromServlet »  Test case throws exception: sendRecvTopicTestUsingCDIFromServlet failed
[ERROR]   ClientTest.sendRecvUsingCDIDefaultFactoryFromServlet »  Test case throws exception: sendRecvUsingCDIDefaultFactoryFromServlet failed
[ERROR]   ClientTest.testActiveJTAUsingCDIAcross2MethodsFromEjb »  Test case throws exception: testActiveJTAUsingCDIAcross2MethodsFromEjb failed
[ERROR]   ClientTest.testRestrictionsOnCDIJMSContextFromServlet »  Test case throws exception: testRestrictionsOnCDIJMSContextFromServlet failed
[ERROR]   ClientTest.verifySessionModeOnCDIJMSContextFromServlet »  Test case throws exception: verifySessionModeOnCDIJMSContextFromServlet failed
[INFO] 
[ERROR] Tests run: 13, Failures: 0, Errors: 8, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:01 min
[INFO] Finished at: 2025-05-08T19:08:00-05:00
[INFO] ------------------------------------------------------------------------
```
